### PR TITLE
Fix: Adjust sendLocalList command types and add to centralSystemActions

### DIFF
--- a/docs/modules/messages/soap/wsdl/ChargePointService/ChargePointServiceSoap12.ts.md
+++ b/docs/modules/messages/soap/wsdl/ChargePointService/ChargePointServiceSoap12.ts.md
@@ -447,9 +447,7 @@ export interface ISendLocalListInput {
   updateType: 'Differential' | 'Full'
   /** urn://Ocpp/Cp/2012/06/#s:int(undefined) */
   listVersion: number
-  localAuthorisationList: ChargePointServiceSoap12Types.IlocalAuthorisationList[]
-  /** urn://Ocpp/Cp/2012/06/#s:string(undefined) */
-  hash: string
+  localAuthorizationList: ChargePointServiceSoap12Types.IlocalAuthorizationList[]
 }
 ```
 
@@ -461,8 +459,6 @@ export interface ISendLocalListInput {
 export interface ISendLocalListOutput {
   /** urn://Ocpp/Cp/2012/06/#UpdateStatus(Accepted,Failed,HashError,NotSupported,VersionMismatch) */
   status: 'Accepted' | 'Failed' | 'HashError' | 'NotSupported' | 'VersionMismatch'
-  /** urn://Ocpp/Cp/2012/06/#s:string(undefined) */
-  hash: string
 }
 ```
 

--- a/src/messages/cs/index.ts
+++ b/src/messages/cs/index.ts
@@ -32,7 +32,8 @@ export const centralSystemActions: CentralSystemAction<'v1.6-json'>[] = [
   "TriggerMessage",
   "UnlockConnector",
   "UpdateFirmware",
-  "SetChargingProfile"
+  "SetChargingProfile",
+  "SendLocalList"
 ];
 
 export const soapCentralSystemActions: CentralSystemAction<'v1.5-soap'>[] = [
@@ -51,7 +52,8 @@ export const soapCentralSystemActions: CentralSystemAction<'v1.5-soap'>[] = [
   "SendLocalList",
   "UnlockConnector",
   "UpdateFirmware",
-  "SetChargingProfile"
+  "SetChargingProfile",
+  "SendLocalList"
 ];
 
 export type CentralSystemRequest<T extends CentralSystemAction, V extends OCPPVersion = OCPPVersion> = CentralSystemMessage<V>[T]['request'];

--- a/src/messages/json/request/SendLocalList.json
+++ b/src/messages/json/request/SendLocalList.json
@@ -15,7 +15,7 @@
                         "type": "string",
                         "maxLength": 20
                     },
-                    "tagInfo": {
+                    "idTagInfo": {
                         "type": "object",
 						"expiryDate": {
 							"type": "string",

--- a/src/messages/json/request/SendLocalList.json
+++ b/src/messages/json/request/SendLocalList.json
@@ -15,7 +15,7 @@
                         "type": "string",
                         "maxLength": 20
                     },
-                    "idTagInfo": {
+                    "tagInfo": {
                         "type": "object",
 						"expiryDate": {
 							"type": "string",

--- a/src/messages/soap/wsdl/ChargePointService/ChargePointServiceSoap12.ts
+++ b/src/messages/soap/wsdl/ChargePointService/ChargePointServiceSoap12.ts
@@ -203,9 +203,7 @@ export interface ISendLocalListInput {
   updateType: "Differential" | "Full";
   /** urn://Ocpp/Cp/2012/06/#s:int(undefined) */
   listVersion: number;
-  localAuthorisationList: ChargePointServiceSoap12Types.IlocalAuthorisationList[];
-  /** urn://Ocpp/Cp/2012/06/#s:string(undefined) */
-  hash: string;
+  localAuthorizationList: ChargePointServiceSoap12Types.IlocalAuthorizationList[];
 }
 
 export interface ISendLocalListOutput {
@@ -216,8 +214,6 @@ export interface ISendLocalListOutput {
     | "HashError"
     | "NotSupported"
     | "VersionMismatch";
-  /** urn://Ocpp/Cp/2012/06/#s:string(undefined) */
-  hash: string;
 }
 
 export interface IChargePointServiceSoap12Soap {
@@ -401,11 +397,11 @@ export namespace ChargePointServiceSoap12Types {
     /** urn://Ocpp/Cp/2012/06/#AuthorizationStatus(Accepted,Blocked,Expired,Invalid,ConcurrentTx) */
     status: "Accepted" | "Blocked" | "Expired" | "Invalid" | "ConcurrentTx";
     /** urn://Ocpp/Cp/2012/06/#s:dateTime(undefined) */
-    expiryDate: Date;
+    expiryDate?: Date;
     /** urn://Ocpp/Cp/2012/06/#IdToken(maxLength) */
-    parentIdTag: string;
+    parentIdTag?: string;
   }
-  export interface IlocalAuthorisationList {
+  export interface IlocalAuthorizationList {
     /** urn://Ocpp/Cp/2012/06/#IdToken(maxLength) */
     idTag: string;
     idTagInfo: ChargePointServiceSoap12Types.IidTagInfo;


### PR DESCRIPTION
Changes:

Renaming of the interface IlocalAuthorisationList to IlocalAuthorizationList.

Addition of the SendLocalList command in the centralSystemActions and soapCentralSystemActions: This addition allows sending the OCPP command to a station.

Update in the IidTagInfo interface: According to the "Open Charge Point Protocol 1.6" documentation, the expiryDate and parentIdTag fields have now become optional. This modification provides more flexibility when using the interface.