### PR TITLE
Remove timeouts of messages when the connection is closed in either side

### DIFF
--- a/docs/modules/cs/index.ts.md
+++ b/docs/modules/cs/index.ts.md
@@ -77,7 +77,7 @@ public addConnectionListener(listener: ConnectionListener)
 **Signature**
 
 ```ts
-public close(): Promise<void>
+public async close(): Promise<void>
 ```
 
 ### sendRequest (method)


### PR DESCRIPTION
## Why

Currently we are not clearing timeouts on sending messages and receiving responses on the Connection, this can cause some problems due to the fact the connection is already closed but the timeouts can still happend throwing unhandled expections.

## How

Upon closing a connection we have cleared all timeouts in the connection so no error can happen. We do not need the timeout anymore as the connection do not exist.
