### PR TITLE
Fix: check if connections exist before closing them

### DIFF
--- a/src/cs/index.ts
+++ b/src/cs/index.ts
@@ -165,7 +165,9 @@ export default class CentralSystem {
 
   public async closeConnection(chargePointId: string): Promise<void> {
     const connections = this.connections[chargePointId];
-    await Promise.all(connections.map((connection) => connection.close()));
+    if (connections) {
+      await Promise.all(connections.map((connection) => connection.close()));
+    }
   }
 
   sendRequest<V extends OCPPVersion, T extends CentralSystemAction>(args: CSSendRequestArgs<T, V>): EitherAsync<OCPPRequestError, Response<T, V>> {


### PR DESCRIPTION
The pull request https://github.com/voltbras/ts-ocpp/pull/53 added a new feature to the CentralSystem to close a connection from a ChargePoint, some ChargePoints with bad implemented code can open more than one connection, where one connection will be the active, where the ChargePoint will send and receive commands, the other connections will be stale and not used for communication.

Unfortunately, we have assumed we would always get a connection to close, this does not seem to be true. This PR checks if the connections exist before closing them.