### PR TITLE
CELO-261 Feat(ts-ocpp): Allows central-system to close chargepoint connections

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,5 +47,6 @@
   ],
   "publishConfig": {
     "registry": "https://npm.pkg.github.com/"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/src/cs/index.ts
+++ b/src/cs/index.ts
@@ -152,10 +152,10 @@ export default class CentralSystem {
     this.listeners.push(listener);
   }
 
-  public async close(): Promise<void> {
+  public async close(code?: number): Promise<void> {
     Object.values(this.connections).map((chargepointConnections) => {
       chargepointConnections.map((connection) => {
-        connection.close();
+        connection.close(code);
       });
     })
     const httpClosing = new Promise(resolve => this.httpServer.close(resolve));
@@ -163,10 +163,10 @@ export default class CentralSystem {
     return Promise.all([httpClosing, wsClosing]).then(() => { });
   }
 
-  public async closeConnection(chargePointId: string): Promise<void> {
+  public async closeConnection(chargePointId: string, code?: number): Promise<void> {
     const connections = this.connections[chargePointId];
     if (connections) {
-      await Promise.all(connections.map((connection) => connection.close()));
+      await Promise.all(connections.map((connection) => connection.close(code)));
     }
   }
 

--- a/src/ws/connection.ts
+++ b/src/ws/connection.ts
@@ -82,13 +82,13 @@ export default class Connection<ReqAction extends ActionName<'v1.6-json'>> {
       })
   }
 
-  public close() {
+  public close(code?: number) {
     Object.entries(this.timeouts).forEach(([requestId, timeout]) => {
       clearTimeout(timeout);
       delete this.messageTriggers[requestId];
       delete this.timeouts[requestId];
     });
-    this.socket.close();
+    this.socket.close(code);
   }
 
   private async sendOCPPMessage(message: OCPPJMessage): Promise<void> {

--- a/src/ws/constants.ts
+++ b/src/ws/constants.ts
@@ -1,3 +1,2 @@
 export const OCPP_1_6 = 'ocpp1.6';
 export const SUPPORTED_PROTOCOLS = [OCPP_1_6];
-export const CONCURRENT_CONNECTION_TERMINATED_CODE = 4500;

--- a/src/ws/constants.ts
+++ b/src/ws/constants.ts
@@ -1,2 +1,3 @@
 export const OCPP_1_6 = 'ocpp1.6';
 export const SUPPORTED_PROTOCOLS = [OCPP_1_6];
+export const CONCURRENT_CONNECTION_TERMINATED_CODE = 4500;


### PR DESCRIPTION
# WHY
Whenever the central-system closes a concurrent ws connection, the cs-proxy should do the same. In order to signal the cs-proxy to close the corresponding chargepoint connection, we must close the cs-proxy <-> central-system connection with a specific application defined code.

Application specific codes in websockets are in the range of 4000 to 4999: https://github.com/Luka967/websocket-close-codes

# HOW
Adds a new parameter to the closeConnection method of the centralSystem `code`, which is a number that will be passed to the close method of the WebSocket instance

# RELEASE NOTES
- Allows central systems to specify a code whenever closing a connection