### PR TITLE
Feat(boot-notification): Add Pending status to BootNotificationOutput response

### DIFF
--- a/src/messages/soap/wsdl/CentralSystemService/CentralSystemServiceSoap12.ts
+++ b/src/messages/soap/wsdl/CentralSystemService/CentralSystemServiceSoap12.ts
@@ -133,7 +133,7 @@ export interface IBootNotificationInput {
 
 export interface IBootNotificationOutput {
     /** urn://Ocpp/Cs/2012/06/#RegistrationStatus(Accepted,Rejected) */
-    status: "Accepted" | "Rejected";
+    status: "Accepted" | "Rejected" | 'Pending';
     /** urn://Ocpp/Cs/2012/06/#s:dateTime(undefined) */
     currentTime: string;
     /** urn://Ocpp/Cs/2012/06/#s:int(undefined) */


### PR DESCRIPTION
<img width="998" alt="image" src="https://github.com/user-attachments/assets/8264cf55-5b4c-4130-a35a-e537a8faba29" />
As described at OCPP 1.6 protocol, the status code response at Boot Notification can be Pending, that was missing in ts-ocpp.