### PR TITLE
fix(cs): Make sure CentralSystemOptions are spread after defaults

### DIFF
--- a/src/cs/index.ts
+++ b/src/cs/index.ts
@@ -121,10 +121,10 @@ export default class CentralSystem {
     this.cpHandler = cpHandler;
     const host = options.host ?? '0.0.0.0';
     this.options = {
-      ...options,
-      rejectInvalidRequests: options.rejectInvalidRequests ?? true,
+      rejectInvalidRequests: true,
       websocketPingInterval: 30_000,
-      websocketAuthorizer: options.websocketAuthorizer ?? (() => true),
+      websocketAuthorizer: () => true,
+      ...options,
     };
     debug('creating central system on port %d - options: %o', port, this.options);
 


### PR DESCRIPTION
In the current implementation, spreading CentralSystemOptions before their default value will not set the options values in params. It means that `websocketPingInterval` was always set as `30000` milliseconds regardless of the value passed by the CentralSystemOptions.